### PR TITLE
Djordjevic sarkar casual dieletric model

### DIFF
--- a/inc/layers.hpp
+++ b/inc/layers.hpp
@@ -39,6 +39,23 @@
 #include <set>
 
 
+/*! \brief Selects the dielectric dispersion model used for a layer's permittivity.*/
+enum class DielectricModelType { CONSTANT, DJORDJEVIC_SARKAR };
+
+
+/*! \brief Parameters of the causal Djordjevic-Sarkar wideband dielectric model. Field names follow the HFSS Djordjevic-Sarkar Model Input dialog.*/
+struct DjordjevicSarkarParams
+{
+	double relative_permittivity;             /// dk at the measurement frequency
+	double loss_tangent;                      /// df (tan delta) at the measurement frequency
+	double at_frequency = 1e9;                /// measurement frequency [Hz]
+	double conductivity_at_dc = 1e-12;        /// DC conductivity [S/m]
+	double relative_permittivity_at_dc = -1.0; /// permittivity at DC; negative means not set
+	double lower_frequency = 1e3;             /// lower transition (corner) frequency [Hz]
+	double upper_frequency = 1e11;            /// upper transition (corner) frequency [Hz]
+};
+
+
 /*! \brief Class to store and manage frequency-dependent information for each layer.*/
 class Layer
 {
@@ -49,6 +66,8 @@ public:
 	int layerID;
 	double zmax, zmin, h, sigma, mur, sigmamu;
 	std::complex<double> epsr;
+	DielectricModelType dielectric_model = DielectricModelType::CONSTANT;
+	DjordjevicSarkarParams ds_params;
 	std::vector<int> objectIDs;   /// List of indices of objects that belong to this layer
 	std::vector<double> obj_zmin, obj_zmax;  /// Min and max z extent of each object
 
@@ -88,7 +107,7 @@ public:
 	void ProcessTechFile_yaml(std::string tech_file, double units = 1.0e-9);
 	void ProcessTechFile_tech(std::string tech_file, double units = 1.0e-9);
 	
-	void AddLayer(double zmin, double zmax, std::complex<double> epsr, double mur, double sigma, double sigmamu);
+	void AddLayer(double zmin, double zmax, std::complex<double> epsr, double mur, double sigma, double sigmamu, DielectricModelType model = DielectricModelType::CONSTANT, DjordjevicSarkarParams ds = {});
 	void SetHalfspaces(double _epsr_top, double _mur_top, double _sigma_top, double _epsr_bot, double _mur_bot, double _sigma_bot, bool _isPEC_top, bool _isPEC_bot);
 	
 	void ProcessLayers(double f);

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -116,21 +116,55 @@ void LayerManager::ProcessTechFile_yaml(std::string tech_file, double units)
 
 			double zmin = layer["zmin"].as<double> ();
 			double h = layer["h"].as<double> ();
-			
+
 			zmin *= units;
 			h *= units;
 			double zmax = zmin + h;
 
-			double epsr_real = layer["epsr"].as<double> (1.0);
 			double mur = layer["mur"].as<double> (1.0);
-			double epsr_im = layer["epsr_im"].as<double> (0.0);
-			double sigma = layer["sigma"].as<double> (0.0);
 			double sigmamu = layer["sigmamu"].as<double> (0.0);
 
-			std::complex<double> epsr = {epsr_real, epsr_im};
+			if (layer["epsr"] && layer["epsr"].IsMap())
+			{
+				// Frequency-dependent dispersion model
+				const YAML::Node &m = layer["epsr"];
+				std::string model_name = m["model"].as<std::string> ();
 
-			// Add this layer to the full layer-set
-			AddLayer(zmin, zmax, epsr, mur, sigma, sigmamu);
+				if (model_name != "djordjevic_sarkar")
+					throw std::runtime_error("[ERROR] LayerManager::ProcessTechFile_yaml(): Unknown dielectric model '" + model_name + "' in layer " + label);
+
+				DjordjevicSarkarParams ds;
+				ds.relative_permittivity = m["relative_permittivity"].as<double> ();
+				ds.loss_tangent = m["loss_tangent"].as<double> ();
+				ds.at_frequency = m["at_frequency"].as<double> (1e9);
+				ds.conductivity_at_dc = m["conductivity_at_dc"].as<double> (1e-12);
+				ds.lower_frequency = m["lower_frequency"].as<double> (1e3);
+				ds.upper_frequency = m["upper_frequency"].as<double> (1e11);
+				if (m["relative_permittivity_at_dc"])
+					ds.relative_permittivity_at_dc = m["relative_permittivity_at_dc"].as<double> ();
+
+				// Validation (mirrors HFSS: dk > 1, df >= 0)
+				if (ds.relative_permittivity <= 1.0)
+					throw std::runtime_error("[ERROR] LayerManager::ProcessTechFile_yaml(): djordjevic_sarkar relative_permittivity must be > 1 in layer " + label);
+				if (ds.loss_tangent < 0.0)
+					throw std::runtime_error("[ERROR] LayerManager::ProcessTechFile_yaml(): djordjevic_sarkar loss_tangent must be >= 0 in layer " + label);
+
+				// Placeholder epsr, overwritten per-frequency in ProcessLayers. DC loss is carried by sigma.
+				std::complex<double> epsr = {ds.relative_permittivity, 0.0};
+				AddLayer(zmin, zmax, epsr, mur, ds.conductivity_at_dc, sigmamu, DielectricModelType::DJORDJEVIC_SARKAR, ds);
+			}
+			else
+			{
+				// Constant (frequency-independent) permittivity
+				double epsr_real = layer["epsr"].as<double> (1.0);
+				double epsr_im = layer["epsr_im"].as<double> (0.0);
+				double sigma = layer["sigma"].as<double> (0.0);
+
+				std::complex<double> epsr = {epsr_real, epsr_im};
+
+				// Add this layer to the full layer-set
+				AddLayer(zmin, zmax, epsr, mur, sigma, sigmamu);
+			}
 		}
 	}
 	else
@@ -311,7 +345,7 @@ void LayerManager::ProcessTechFile_tech(std::string tech_file, double units)
 
 
 /*! \brief Function to add a new layer to the layer set. It is the user's responsibility to make sure that the z_min and z_max do not overlap with the z-extent of any other layer in the set.*/
-void LayerManager::AddLayer(double zmin, double zmax, std::complex<double> epsr, double mur, double sigma, double sigmamu)
+void LayerManager::AddLayer(double zmin, double zmax, std::complex<double> epsr, double mur, double sigma, double sigmamu, DielectricModelType model, DjordjevicSarkarParams ds)
 {
 
 	if (zmax - zmin <= 0.0)
@@ -340,6 +374,8 @@ void LayerManager::AddLayer(double zmin, double zmax, std::complex<double> epsr,
 
 	// Create a new layer
 	Layer layer (zmin, zmax, epsr, mur, sigma, sigmamu);
+	layer.dielectric_model = model;
+	layer.ds_params = ds;
 	layers.insert(layers.begin() + position, layer);
 	
 	return;
@@ -364,6 +400,34 @@ void LayerManager::SetHalfspaces(double _epsr_top, double _mur_top, double _sigm
 	isPEC_bot = _isPEC_bot;
 
 	return;
+
+}
+
+
+/*! \brief Evaluates the causal Djordjevic-Sarkar complex relative permittivity at angular frequency omega. Derives eps_inf and delta_eps so that Re[epsr] and tan(delta) match the specified values at the measurement frequency.*/
+static std::complex<double> ComputeDjordjevicSarkar(const DjordjevicSarkarParams &p, double omega)
+{
+
+	const double omega_ref = 2.0*M_PI*p.at_frequency;
+	const double omega1 = 2.0*M_PI*p.lower_frequency;
+	const double omega2 = 2.0*M_PI*p.upper_frequency;
+	const double ln_ratio = std::log(omega2/omega1);
+
+	// Log term of the D-S model evaluated at the measurement frequency
+	std::complex<double> log_ref = std::log(std::complex<double>(omega2, omega_ref) / std::complex<double>(omega1, omega_ref));
+
+	// Solve the two anchor conditions:
+	//   Re[epsr(omega_ref)] = relative_permittivity
+	//   -Im[epsr(omega_ref)]/Re[epsr(omega_ref)] = loss_tangent
+	double delta_eps = -p.relative_permittivity*p.loss_tangent*ln_ratio / log_ref.imag();
+	double eps_inf = p.relative_permittivity - delta_eps*log_ref.real()/ln_ratio;
+
+	// Evaluate the model at the requested frequency
+	std::complex<double> log_f = std::log(std::complex<double>(omega2, omega) / std::complex<double>(omega1, omega));
+
+	return eps_inf + delta_eps*log_f/ln_ratio;
+	// Note: DC conductivity is stored in Layer::sigma and handled by the existing
+	// epsilon_complex lambda (the -sigma/omega term) in ProcessLayers.
 
 }
 
@@ -413,6 +477,9 @@ void LayerManager::ProcessLayers(double f)
 	{
 
 		layers[ii].layerID = ii;
+
+		if (layers[ii].dielectric_model == DielectricModelType::DJORDJEVIC_SARKAR)
+			layers[ii].epsr = ComputeDjordjevicSarkar(layers[ii].ds_params, omega);
 
 		eps[ii] = epsilon_complex(eps0, layers[ii].epsr, layers[ii].sigma, omega);
 		mu[ii] = std::complex<double> ((layers[ii].mur * mu0), 0.0);
@@ -858,8 +925,12 @@ void LayerManager::MergeLayersWithSameMaterial(double tol)
 
 		int jj = ii - 1; // The layer above
 
-		// Check if the layer above is of the same material as this one
-		if (std::abs(layers[ii].epsr - layers[jj].epsr) < tol &&
+		// Check if the layer above is of the same material as this one. Layers using a
+		// dispersion model are never merged, since their stored epsr is a placeholder that
+		// does not capture the model parameters.
+		if (layers[ii].dielectric_model == DielectricModelType::CONSTANT &&
+		    layers[jj].dielectric_model == DielectricModelType::CONSTANT &&
+		    std::abs(layers[ii].epsr - layers[jj].epsr) < tol &&
 		    std::abs(layers[ii].mur - layers[jj].mur) < tol &&
 		    std::abs(layers[ii].epsr.real() - layers[jj].epsr.imag()) < tol &&
 		    std::abs(layers[ii].sigma - layers[jj].sigma) < tol &&

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -695,7 +695,27 @@ void LayerManager::PrintLayerData(std::ofstream *out_file, bool print_to_termina
 		message += "zmax: " + std::to_string(layers[ii].zmax) + "\n";
 		message += "zmin: " + std::to_string(layers[ii].zmin) + "\n";
 		message += "Height: " + std::to_string(layers[ii].h) + "\n";
-		message += "Relative permittivity: " + std::to_string(layers[ii].epsr.real()) + get_signed_imag_string(layers[ii].epsr.imag()) + "\n";
+		if (layers[ii].dielectric_model == DielectricModelType::DJORDJEVIC_SARKAR)
+		{
+			const auto &ds = layers[ii].ds_params;
+			message += "Dielectric model: Djordjevic-Sarkar (causal wideband)\n";
+			message += "  Relative permittivity at " + std::to_string(ds.at_frequency) + " Hz: " + std::to_string(ds.relative_permittivity) + "\n";
+			message += "  Loss tangent at " + std::to_string(ds.at_frequency) + " Hz: " + std::to_string(ds.loss_tangent) + "\n";
+			message += "  Lower corner frequency: " + std::to_string(ds.lower_frequency) + " Hz\n";
+			message += "  Upper corner frequency: " + std::to_string(ds.upper_frequency) + " Hz\n";
+			message += "  DC conductivity: " + std::to_string(ds.conductivity_at_dc) + " S/m\n";
+			if (layers_processed)
+			{
+				double tand_eff = (layers[ii].epsr.real() > 0.0) ? -layers[ii].epsr.imag() / layers[ii].epsr.real() : 0.0;
+				message += "  Effective epsr (at last evaluated freq): " + std::to_string(layers[ii].epsr.real()) + get_signed_imag_string(layers[ii].epsr.imag()) + "\n";
+				message += "  Effective tan(delta): " + std::to_string(tand_eff) + "\n";
+			}
+		}
+		else
+		{
+			message += "Dielectric model: constant\n";
+			message += "Relative permittivity: " + std::to_string(layers[ii].epsr.real()) + get_signed_imag_string(layers[ii].epsr.imag()) + "\n";
+		}
 		message += "Relative permeability: " + std::to_string(layers[ii].mur) + "\n";
 		message += "Electrical conductivity: " + std::to_string(layers[ii].sigma) + "\n";
 		if (layers_processed)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,3 +49,7 @@ add_executable(testSpectralMGF ${SRC_DIR}/testSpectralMGF.cpp)
 target_include_directories(testSpectralMGF PRIVATE ${INC_DIR} ${STRATA_INC})
 target_link_libraries(testSpectralMGF PRIVATE strata)
 
+add_executable(testDjordjevicSarkar ${SRC_DIR}/testDjordjevicSarkar.cpp)
+target_include_directories(testDjordjevicSarkar PRIVATE ${INC_DIR} ${STRATA_INC})
+target_link_libraries(testDjordjevicSarkar PRIVATE strata)
+

--- a/test/testDjordjevicSarkar.cpp
+++ b/test/testDjordjevicSarkar.cpp
@@ -1,0 +1,103 @@
+// Unit test for the Djordjevic-Sarkar causal dielectric model.
+//
+// Verifies, through the public LayerManager API, that:
+//   1. At the measurement frequency, the effective layer permittivity reproduces
+//      the specified relative permittivity and loss tangent.
+//   2. The loss tangent stays approximately flat across a wide band (1-10 GHz).
+//   3. A dielectric-model layer is never merged away by MergeLayersWithSameMaterial.
+
+#include <cmath>
+#include <complex>
+#include <iostream>
+#include <stdexcept>
+
+#include "layers.hpp"
+#include "constants.hpp"
+
+
+static int failures = 0;
+
+static void check(bool cond, const std::string &msg)
+{
+	if (!cond)
+	{
+		std::cout << "[FAIL] " << msg << std::endl;
+		failures++;
+	}
+	else
+	{
+		std::cout << "[ OK ] " << msg << std::endl;
+	}
+}
+
+
+int main()
+{
+	std::cout << "===========================" << std::endl;
+	std::cout << "TestDjordjevicSarkar()" << std::endl;
+	std::cout << "===========================" << std::endl;
+
+	const double dk = 4.4;
+	const double df = 0.02;
+	const double f_ref = 1e9;
+
+	// ------ Build a two-layer stack: one D-S layer, one constant layer ------
+
+	DjordjevicSarkarParams ds;
+	ds.relative_permittivity = dk;
+	ds.loss_tangent = df;
+	ds.at_frequency = f_ref;
+
+	LayerManager lm;
+	// D-S layer on top, constant layer below (different material)
+	lm.AddLayer(0.0, 50e-6, {dk, 0.0}, 1.0, ds.conductivity_at_dc, 0.0, DielectricModelType::DJORDJEVIC_SARKAR, ds);
+	lm.AddLayer(-50e-6, 0.0, {12.5, 0.0}, 1.0, 0.0, 0.0);
+
+	// ------ Test 1: anchor conditions at the measurement frequency ------
+
+	lm.ProcessLayers(f_ref);
+
+	// Find the D-S layer (its dielectric_model flag survives)
+	int ds_idx = -1;
+	for (int i = 0; i < (int)lm.layers.size(); i++)
+		if (lm.layers[i].dielectric_model == DielectricModelType::DJORDJEVIC_SARKAR)
+			ds_idx = i;
+
+	check(ds_idx >= 0, "D-S layer present after ProcessLayers (not merged away)");
+	check(lm.layers.size() == 2, "layer count unchanged (no spurious merge)");
+
+	// eps[] is the absolute complex permittivity; divide by eps0 for relative
+	std::complex<double> epsr_eff = lm.eps[ds_idx] / strata::eps0;
+	double re = epsr_eff.real();
+	double tand = -epsr_eff.imag() / epsr_eff.real();
+
+	std::cout << "  epsr(f_ref) = " << re << ", tan(delta) = " << tand << std::endl;
+
+	check(std::abs(re - dk) / dk < 1e-6, "Re[epsr] matches relative_permittivity at f_ref");
+	check(std::abs(tand - df) / df < 1e-3, "tan(delta) matches loss_tangent at f_ref");
+
+	// ------ Test 2: loss tangent stays roughly flat across 1-10 GHz ------
+
+	double tand_min = 1e300, tand_max = -1e300;
+	for (double f = 1e9; f <= 10e9; f += 1e9)
+	{
+		lm.ProcessLayers(f);
+		std::complex<double> e = lm.eps[ds_idx] / strata::eps0;
+		double t = -e.imag() / e.real();
+		tand_min = std::min(tand_min, t);
+		tand_max = std::max(tand_max, t);
+	}
+	std::cout << "  tan(delta) over 1-10 GHz: [" << tand_min << ", " << tand_max << "]" << std::endl;
+	check((tand_max - tand_min) / df < 0.10, "tan(delta) flat within 10% across 1-10 GHz");
+
+	// ------ Summary ------
+
+	std::cout << "===========================" << std::endl;
+	if (failures == 0)
+		std::cout << "All checks passed." << std::endl;
+	else
+		std::cout << failures << " check(s) FAILED." << std::endl;
+	std::cout << "===========================" << std::endl;
+
+	return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Implementation of Djordjevic-Sarkar casual dielectric model. Example used in testing will be updated in Rebel repo.

Here I used a simple microstrip (20mm). Compared with TLX, 2D extractor, the S parameters have a good agreement.

<img width="1781" height="1287" alt="image" src="https://github.com/user-attachments/assets/a3501c77-d89c-4b62-9a7b-902a7472c6f1" />
